### PR TITLE
mptcp: don't parse partial options that are 1 byte in size

### DIFF
--- a/net/mptcp/mptcp_input.c
+++ b/net/mptcp/mptcp_input.c
@@ -1146,6 +1146,8 @@ struct mp_join *mptcp_find_join(const struct sk_buff *skb)
 			length--;
 			continue;
 		default:
+			if (length == 1)	/* not enough room for opsize */
+				return NULL;
 			opsize = *ptr++;
 			if (opsize < 2)	/* "silly options" */
 				return NULL;
@@ -1859,6 +1861,8 @@ void tcp_parse_mptcp_options(const struct sk_buff *skb,
 			length--;
 			continue;
 		default:
+			if (length == 1)	/* not enough room for opsize */
+				return;
 			opsize = *ptr++;
 			if (opsize < 2)	/* "silly options" */
 				return;


### PR DESCRIPTION
When parsing options (in mptcp_find_join() and in tcp_parse_mptcp_options()), the kernel checks if there is enough room for the opcode (which is sufficient for NOP and EOL), but not if there's any room for the oplen. Unless a page fault occurs, the functions still behave correctly.

A SYN with a data offset of 6 (i. e. 4 bytes for options) that has 3 NOPs followed by, say, a timestamp opcode, could run afoul of this bug.

It seems I'll have to send an upstream patch too; tcp_parse_options has the same problem (http://lxr.free-electrons.com/source/net/ipv4/tcp_input.c#L3670).
