### PR TITLE
mptcp_sysctl: expose sockopt MPTCP_ENABLED value via sysctl

### DIFF
--- a/net/mptcp/mptcp_ctrl.c
+++ b/net/mptcp/mptcp_ctrl.c
@@ -70,6 +70,7 @@ int sysctl_mptcp_checksum __read_mostly = 1;
 int sysctl_mptcp_debug __read_mostly;
 EXPORT_SYMBOL(sysctl_mptcp_debug);
 int sysctl_mptcp_syn_retries __read_mostly = 3;
+static const int sysctl_sockopt_mptcp_enabled = MPTCP_ENABLED;
 
 bool mptcp_init_failed __read_mostly;
 
@@ -130,6 +131,13 @@ static struct ctl_table mptcp_table[] = {
 		.proc_handler = &proc_dointvec_minmax,
 		.extra1 = &min_mptcp_version,
 		.extra2 = &max_mptcp_version,
+	},
+	{
+		.procname = "sockopt_mptcp_enabled",
+		.data = (void *)&sysctl_sockopt_mptcp_enabled,
+		.mode = 0444,
+		.maxlen = sizeof(int),
+		.proc_handler = &proc_dointvec
 	},
 	{
 		.procname = "mptcp_checksum",


### PR DESCRIPTION
This allow mptcp applications using sockopt MPTCP_ENABLED to be indepedant regarding kernel or mptcp version. This could be extended to test if others "MPTCP_" sockopt features are availables or enabled like the sock_api or sock_scheduler.

```
root@OpenWrt:~# sysctl net.mptcp.sockopt_mptcp_enabled
net.mptcp.sockopt_mptcp_enabled = 42

root@OpenWrt:~# cat /proc/sys/net/mptcp/sockopt_mptcp_enabled 
42

root@OpenWrt:~# ls -alh /proc/sys/net/mptcp/sockopt_mptcp_enabled
-r--r--r--    1 root     root           0 Dec 28 18:57 /proc/sys/net/mptcp/sockopt_mptcp_enabled
```