### PR TITLE
mptcp: fix sk_buff NULL pointer dereference in BLEST scheduler

### DIFF
--- a/net/mptcp/mptcp_blest.c
+++ b/net/mptcp/mptcp_blest.c
@@ -201,6 +201,7 @@ struct sock *blest_get_available_subflow(struct sock *meta_sk, struct sk_buff *s
 	/* if we decided to use a slower flow, we have the option of not using it at all */
 	if (bestsk && minsk && bestsk != minsk) {
 		u32 slow_linger_time, fast_bytes, slow_inflight_bytes, slow_bytes, avail_space;
+		u32 buffered_bytes = 0;
 
 		meta_tp = tcp_sk(meta_sk);
 		besttp = tcp_sk(bestsk);
@@ -213,13 +214,16 @@ struct sock *blest_get_available_subflow(struct sock *meta_sk, struct sk_buff *s
 		slow_linger_time = blestsched_estimate_linger_time(bestsk);
 		fast_bytes = blestsched_estimate_bytes(minsk, slow_linger_time);
 
+		if (skb)
+			buffered_bytes = skb->len;
+
 		/* is the required space available in the mptcp meta send window?
 		 * we assume that all bytes inflight on the slow path will be acked in besttp->srtt seconds
 		 * (just like the SKB if it was sent now) -> that means that those inflight bytes will
 		 * keep occupying space in the meta window until then
 		 */
 		slow_inflight_bytes = besttp->write_seq - besttp->snd_una;
-		slow_bytes = skb->len + slow_inflight_bytes; // bytes of this SKB plus those in flight already
+		slow_bytes = buffered_bytes + slow_inflight_bytes; // bytes of this SKB plus those in flight already
 
 		avail_space = (slow_bytes < meta_tp->snd_wnd) ? (meta_tp->snd_wnd - slow_bytes) : 0;
 


### PR DESCRIPTION
```blest_get_available_subflow``` uses ```skb->len``` together with the amount of
already inflight bytes on the choosen subflow to estimate the overall
available space in the send window.

This commit adds a check if ```skb``` is ```NULL``` so that we just assume 0 bytes
to add to the available space in that case. This will cause BLEST more
likely to detect a potential HoL-blocking situation where
```fast_bytes > avail_space``` trigger BLEST to return ```NULL``` instead of the
subflow choosen by the default scheduler.

Fixes: 4ffe6a4 (mptcp: BLocking ESTimation-based (BLEST) Scheduler)
Github-Fixes: #356 (Scheduler BLEST: Panic in 4.19.55)
Signed-off-by: Daniel Weber <weberdaniel@gmx.net>