### PR TITLE
mptcp:redundant fix rtx-tree migration bug

### DIFF
--- a/net/mptcp/mptcp_redundant.c
+++ b/net/mptcp/mptcp_redundant.c
@@ -197,11 +197,9 @@ static struct sk_buff *redsched_next_skb_from_queue(struct sk_buff_head *queue,
 						    struct sock *meta_sk)
 {
 	struct sk_buff *skb;
-	if (!previous) {
-		if (tcp_rtx_queue_head(meta_sk))
-			return tcp_rtx_queue_head(meta_sk);
-		return skb_peek(queue);
-	}
+
+	if (!previous)
+		return tcp_rtx_queue_head(meta_sk) ? : skb_peek(queue);
 
 	/* sk_data->skb stores the last scheduled packet for this subflow.
 	 * If sk_data->skb was scheduled but not sent (e.g., due to nagle),

--- a/net/mptcp/mptcp_redundant.c
+++ b/net/mptcp/mptcp_redundant.c
@@ -197,13 +197,11 @@ static struct sk_buff *redsched_next_skb_from_queue(struct sk_buff_head *queue,
 						    struct sock *meta_sk)
 {
 	struct sk_buff *skb;
-	if (!previous){
-		if (tcp_rtx_queue_head(meta_sk)){
+	if (!previous) {
+		if (tcp_rtx_queue_head(meta_sk))
 			return tcp_rtx_queue_head(meta_sk);
-		}
 		return skb_peek(queue);
 	}
-
 
 	/* sk_data->skb stores the last scheduled packet for this subflow.
 	 * If sk_data->skb was scheduled but not sent (e.g., due to nagle),
@@ -251,7 +249,7 @@ static struct sk_buff *mptcp_red_next_segment(struct sock *meta_sk,
 
 	if (skb_queue_empty(&mpcb->reinject_queue) &&
 	    skb_queue_empty(&meta_sk->sk_write_queue) &&
-		tcp_rtx_queue_empty(meta_sk))
+	    tcp_rtx_queue_empty(meta_sk))
 		/* Nothing to send */
 		return NULL;
 

--- a/net/mptcp/mptcp_redundant.c
+++ b/net/mptcp/mptcp_redundant.c
@@ -197,9 +197,13 @@ static struct sk_buff *redsched_next_skb_from_queue(struct sk_buff_head *queue,
 						    struct sock *meta_sk)
 {
 	struct sk_buff *skb;
-
-	if (!previous)
+	if (!previous){
+		if (tcp_rtx_queue_head(meta_sk)){
+			return tcp_rtx_queue_head(meta_sk);
+		}
 		return skb_peek(queue);
+	}
+
 
 	/* sk_data->skb stores the last scheduled packet for this subflow.
 	 * If sk_data->skb was scheduled but not sent (e.g., due to nagle),
@@ -246,7 +250,8 @@ static struct sk_buff *mptcp_red_next_segment(struct sock *meta_sk,
 	*limit = 0;
 
 	if (skb_queue_empty(&mpcb->reinject_queue) &&
-	    skb_queue_empty(&meta_sk->sk_write_queue))
+	    skb_queue_empty(&meta_sk->sk_write_queue) &&
+		tcp_rtx_queue_empty(meta_sk))
 		/* Nothing to send */
 		return NULL;
 


### PR DESCRIPTION
After the commit introducing rt-tree based retransmit
queue, skb(s) that have been transmitted by a subflow are moved to rt-tree
rtx_queue and deleted from sk_write_queue. If the subflows have different
sending rate, the slower subflow will miss those skb(s) if it doesn't check the
rtx_queue.

This fix makes sure the Redundant scheduler checks the rt-tree based
rtx_queue when it selects the skb to schedule, and check
tcp_rtx_queue_empty before it selects the next segment.

Fixes: c61bc63e8f37 ("Merge tag 'v4.15-rc3' into mptcp_trunk")
Closes: https://github.com/multipath-tcp/mptcp/issues/392
Signed-off-by: Vu Vu <vuanh.vu@ikt.uni-hannover.de>