### PR TITLE
Fix the redundant scheduler issue.

### DIFF
--- a/net/mptcp/mptcp_redundant.c
+++ b/net/mptcp/mptcp_redundant.c
@@ -189,7 +189,7 @@ static void redsched_correct_skb_pointers(struct sock *meta_sk,
 	struct tcp_sock *meta_tp = tcp_sk(meta_sk);
 
 	if (red_p->skb &&
-	    (!after(red_p->skb_start_seq, meta_tp->snd_una) ||
+	    (before(red_p->skb_start_seq, meta_tp->snd_una) ||
 	     after(red_p->skb_end_seq, meta_tp->snd_nxt)))
 		red_p->skb = NULL;
 }


### PR DESCRIPTION
Previously `redsched_correct_skb_pointers `set `red_p->skb = NULL` when `red_p->skb_start_seq == meta_tp->snd_una`.
This issue causes the redundant scheduler keep sending reinjected packets.
Replace `!after` with `before `in line 192.

Closes: https://github.com/multipath-tcp/mptcp/issues/474
Fixes: 7835e7847026 ("mptcp: Fix use-after-free in the redundant scheduler")
Signed-off-by: ytxing <ytxing@mail.ustc.edu.cn>